### PR TITLE
Stop having to do crazy indents

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,3 +33,5 @@ Style/Documentation:
   Enabled: false
 Style/FormatStringToken:
   EnforcedStyle: unannotated
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented


### PR DESCRIPTION
Adding this means that rather than:
```
@practice_group_opportunities ||= PracticeGroupsQuery.new(customer: @customer)
                                                     .practice_group_opportunities.map { |data| opportunities_payload(data) }
```
you can use
```
@practice_group_opportunities ||= PracticeGroupsQuery.new(customer: @customer)
  .practice_group_opportunities.map { |data| opportunities_payload(data) }
```