### PR TITLE
Is this really necessary in 2018

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,8 +21,6 @@ Metrics/BlockLength:
     - spec/**/*.rb
 Metrics/ClassLength:
   Max: 200
-Metrics/LineLength:
-  Max: 80
 Style/Alias:
   EnforcedStyle: prefer_alias
 Style/AndOr:


### PR DESCRIPTION
A bit of research shows the rule came off the back of IBM punch cards and then teletypes and video terminals in the 1970's https://en.wikipedia.org/wiki/Punched_card#I