### PR TITLE
Remove AllCops Include rules to fix coverage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,19 +1,16 @@
 AllCops:
-  Include:
-  - '**/Rakefile'
-  - '**/config.ru'
   Exclude:
-      - Gemfile
-      - Capfile
-      - Guardfile
-      - 'db/**/*'
-      - 'config/**/*'
-      - 'script/**/*'
-      - 'bin/**/*'
-      - 'vendor/**/*'
-      - 'tmp/**/*'
-      - 'spec/support/**/*'
-      - 'config/routes.rb'
+    - Gemfile
+    - Capfile
+    - Guardfile
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
+    - 'bin/**/*'
+    - 'vendor/**/*'
+    - 'tmp/**/*'
+    - 'spec/support/**/*'
+    - 'config/routes.rb'
 Metrics/AbcSize:
   Max: 20
 Metrics/BlockLength:


### PR DESCRIPTION
* The `Include` directive is causing rubocop (0.58) to check those two
  files _only_ and ignore the rest of the project.

With the rule:

```
$ bundle exec rubocop
Inspecting 2 files
..

2 files inspected, no offenses detected
```

Without:

```
$ bundle exec rubocop
Inspecting 22 files
......................

22 files inspected, no offenses detected
```